### PR TITLE
Point to hash-stable released tarballs for Coq 8.5-8.6 versions

### DIFF
--- a/packages/coq/coq.8.5.0/opam
+++ b/packages/coq/coq.8.5.0/opam
@@ -34,7 +34,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5/coq-8.5.tar.gz"
   checksum: [
     "sha256=1af77608d3506bfd22e6b2a40929b42d1692dd96e234153882b3d60c6efac2fe"
     "md5=8ee5081f50277c531a0467299ee8c02d"

--- a/packages/coq/coq.8.5.0~camlp4/opam
+++ b/packages/coq/coq.8.5.0~camlp4/opam
@@ -31,7 +31,7 @@ patches: ["ephemeron-rename.patch"]
 install: [make "install"]
 synopsis: "Formal proof management system"
 url {
-  src: "https://github.com/coq/coq/archive/V8.5.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5/coq-8.5.tar.gz"
   checksum: [
     "sha256=1af77608d3506bfd22e6b2a40929b42d1692dd96e234153882b3d60c6efac2fe"
     "md5=8ee5081f50277c531a0467299ee8c02d"

--- a/packages/coq/coq.8.5.1/opam
+++ b/packages/coq/coq.8.5.1/opam
@@ -33,7 +33,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl1/coq-8.5pl1.tar.gz"
   checksum: [
     "sha256=2765c2c9d38f1e094068b916125ccdee6b44d519c41215bfc2a62cb420153fc7"
     "md5=5b608a502e3e0b1f2120ccf092509c14"

--- a/packages/coq/coq.8.5.2/opam
+++ b/packages/coq/coq.8.5.2/opam
@@ -33,7 +33,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl2/coq-8.5pl2.tar.gz"
   checksum: [
     "sha256=c2339575968aff367b4f35d2f77e182204b217326127fbd76235921112e46511"
     "md5=e7570f73e69a6b7490c31df392ed98f7"

--- a/packages/coq/coq.8.5.2~camlp4/opam
+++ b/packages/coq/coq.8.5.2~camlp4/opam
@@ -30,7 +30,7 @@ depends: [
 install: [make "install"]
 synopsis: "Formal proof management system"
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl2/coq-8.5pl2.tar.gz"
   checksum: [
     "sha256=c2339575968aff367b4f35d2f77e182204b217326127fbd76235921112e46511"
     "md5=e7570f73e69a6b7490c31df392ed98f7"

--- a/packages/coq/coq.8.5.3/opam
+++ b/packages/coq/coq.8.5.3/opam
@@ -35,7 +35,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl3.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl3/coq-8.5pl3.tar.gz"
   checksum: [
     "sha256=c2e059520fd41daacc29a5374f7fdde706c7b10880d8de044de5f33725174bbf"
     "md5=66cf2161bbca229c071a0c5132623f15"

--- a/packages/coq/coq.8.6.1/opam
+++ b/packages/coq/coq.8.6.1/opam
@@ -35,7 +35,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.6.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.6.1/coq-8.6.1.tar.gz"
   checksum: [
     "sha256=ba2e6cca27b064dee2c8d52926896baa7909d0a4ccc3599b4b2bc374ac2ed50a"
     "md5=17d6a99370458b752a45299b9197c29b"

--- a/packages/coq/coq.8.6/opam
+++ b/packages/coq/coq.8.6/opam
@@ -34,7 +34,7 @@ install: [make "install"]
 synopsis: "Formal proof management system"
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.6.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.6/coq-8.6.tar.gz"
   checksum: [
     "sha256=aa58e67d8003da237946e135f9301285201fa8d827064c1162f7613bcde418dc"
     "md5=d60092c39f0cf428b35efff71641c3eb"

--- a/packages/coqide/coqide.8.5.0/opam
+++ b/packages/coqide/coqide.8.5.0/opam
@@ -45,7 +45,7 @@ patches: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5/coq-8.5.tar.gz"
   checksum: [
     "sha256=1af77608d3506bfd22e6b2a40929b42d1692dd96e234153882b3d60c6efac2fe"
     "md5=8ee5081f50277c531a0467299ee8c02d"

--- a/packages/coqide/coqide.8.5.1/opam
+++ b/packages/coqide/coqide.8.5.1/opam
@@ -43,7 +43,7 @@ patches: ["fix-idedeps-double-linking.patch"]
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl1/coq-8.5pl1.tar.gz"
   checksum: [
     "sha256=2765c2c9d38f1e094068b916125ccdee6b44d519c41215bfc2a62cb420153fc7"
     "md5=5b608a502e3e0b1f2120ccf092509c14"

--- a/packages/coqide/coqide.8.5.2/opam
+++ b/packages/coqide/coqide.8.5.2/opam
@@ -41,7 +41,7 @@ install: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl2.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl2/coq-8.5pl2.tar.gz"
   checksum: [
     "sha256=c2339575968aff367b4f35d2f77e182204b217326127fbd76235921112e46511"
     "md5=e7570f73e69a6b7490c31df392ed98f7"

--- a/packages/coqide/coqide.8.5.3/opam
+++ b/packages/coqide/coqide.8.5.3/opam
@@ -41,7 +41,7 @@ install: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.5pl3.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.5pl3/coq-8.5pl3.tar.gz"
   checksum: [
     "sha256=c2e059520fd41daacc29a5374f7fdde706c7b10880d8de044de5f33725174bbf"
     "md5=66cf2161bbca229c071a0c5132623f15"

--- a/packages/coqide/coqide.8.6.1/opam
+++ b/packages/coqide/coqide.8.6.1/opam
@@ -41,7 +41,7 @@ install: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.6.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.6.1/coq-8.6.1.tar.gz"
   checksum: [
     "sha256=ba2e6cca27b064dee2c8d52926896baa7909d0a4ccc3599b4b2bc374ac2ed50a"
     "md5=17d6a99370458b752a45299b9197c29b"

--- a/packages/coqide/coqide.8.6/opam
+++ b/packages/coqide/coqide.8.6/opam
@@ -41,7 +41,7 @@ install: [
 synopsis: "IDE of the Coq formal proof management system."
 flags: light-uninstall
 url {
-  src: "https://github.com/coq/coq/archive/V8.6.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.6/coq-8.6.tar.gz"
   checksum: [
     "sha256=aa58e67d8003da237946e135f9301285201fa8d827064c1162f7613bcde418dc"
     "md5=d60092c39f0cf428b35efff71641c3eb"


### PR DESCRIPTION
Same idea as ocaml/opam-repository#27678